### PR TITLE
Add BAGEL and BOPO Typer CLIs with shared utilities

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,12 @@
+"""Utility modules implementing optimization strategies built on top of Kermut."""
+
+from __future__ import annotations
+
+__all__ = [
+    "PreparedDataset",
+    "ObjectiveConfig",
+    "Direction",
+    "prepare_multiobjective_dataset",
+]
+
+from .utils_data import Direction, ObjectiveConfig, PreparedDataset, prepare_multiobjective_dataset

--- a/strategies/bagel_cli.py
+++ b/strategies/bagel_cli.py
@@ -1,0 +1,172 @@
+"""Typer CLI wrapping a BAGEL-style Monte Carlo exploration on top of Kermut."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+import pandas as pd
+import typer
+
+from .utils_data import PreparedDataset, prepare_multiobjective_dataset, prep_kermut
+from .utils_pareto import non_dominated_sorting, select_diverse
+
+app = typer.Typer(help="BAGEL Monte Carlo exploration tailored for multi-objective assays.")
+
+
+class BAGELPlanner:
+    """Simple Monte Carlo sampler that ranks existing variants using BAGEL energy."""
+
+    def __init__(
+        self,
+        dataset: PreparedDataset,
+        *,
+        model: object | None = None,
+        temperature: float = 1.0,
+        seed: Optional[int] = None,
+    ) -> None:
+        if temperature <= 0:
+            raise ValueError("temperature must be strictly positive.")
+        self.dataset = dataset
+        self.model = model
+        self.temperature = float(temperature)
+        self.rng = np.random.default_rng(seed)
+
+    def _boltzmann_weights(self, energies: np.ndarray) -> np.ndarray:
+        scaled = -energies / self.temperature
+        scaled -= scaled.max()
+        weights = np.exp(scaled)
+        total = weights.sum()
+        if not np.isfinite(total) or total <= 0:
+            return np.full_like(weights, 1.0 / len(weights))
+        return weights / total
+
+    def _candidate_pool(self, batch_size: int, pool_multiplier: int = 25) -> pd.DataFrame:
+        table = self.dataset.table
+        energies = table[self.dataset.energy_column].to_numpy()
+        weights = self._boltzmann_weights(energies)
+        pool_size = min(len(table), max(batch_size * pool_multiplier, batch_size))
+        if pool_size == len(table):
+            indices = np.arange(len(table))
+        else:
+            indices = self.rng.choice(len(table), size=pool_size, replace=False, p=weights)
+        pool = table.iloc[indices].copy()
+        pool["_dataset_index"] = pool.index
+        return pool
+
+    def _select_from_fronts(self, candidate_pool: pd.DataFrame, batch_size: int) -> pd.DataFrame:
+        if len(candidate_pool) <= batch_size:
+            return candidate_pool.reset_index(drop=True)
+
+        fronts = non_dominated_sorting(
+            candidate_pool[self.dataset.signed_columns()].to_numpy()
+        )
+        selected_frames: list[pd.DataFrame] = []
+        remaining = batch_size
+        for front_indices in fronts:
+            if remaining <= 0:
+                break
+            front_df = candidate_pool.iloc[front_indices].copy()
+            if len(front_df) <= remaining:
+                selected_frames.append(front_df)
+                remaining -= len(front_df)
+                continue
+            selected = select_diverse(
+                front_df,
+                remaining,
+                feature_columns=self.dataset.signed_columns(),
+            )
+            selected_frames.append(selected)
+            remaining -= len(selected)
+        if remaining > 0:
+            # Fallback to top-scoring sequences if Pareto fronts are exhausted.
+            leftovers = (
+                candidate_pool.drop(pd.concat(selected_frames).index)
+                .sort_values(self.dataset.score_column, ascending=False)
+                .head(remaining)
+            )
+            if not leftovers.empty:
+                selected_frames.append(leftovers)
+        return pd.concat(selected_frames, ignore_index=True)
+
+    def suggest(self, batch_size: int) -> pd.DataFrame:
+        """Return BAGEL-ranked suggestions with Pareto diversity."""
+
+        pool = self._candidate_pool(batch_size)
+        selected = self._select_from_fronts(pool, batch_size).copy()
+        if "_dataset_index" not in selected.columns:
+            selected["_dataset_index"] = selected.index
+        return selected.reset_index(drop=True)
+
+
+@app.command()
+def suggest(
+    assay_file: Path = typer.Argument(..., help="Path to the TSV/CSV assay table."),
+    *,
+    objectives: Sequence[str] = typer.Option(
+        ..., "--objectives", help="Objective column names, e.g. activity stability."
+    ),
+    directions: Sequence[str] = typer.Option(
+        ..., "--directions", help="Optimisation direction for each objective (max/min)."
+    ),
+    weights: Optional[Sequence[float]] = typer.Option(
+        None, "--weights", help="Relative weight for each objective (defaults to 1.0)."
+    ),
+    checkpoint: Optional[Path] = typer.Option(
+        None, "--checkpoint", help="Optional Kermut checkpoint to warm-start from."
+    ),
+    batch_size: int = typer.Option(96, help="Number of variants to return."),
+    sequence_column: Optional[str] = typer.Option(
+        None, "--sequence-column", help="Column containing amino-acid sequences."
+    ),
+    batch_column: str = typer.Option("batch", help="Column describing assay batch numbers."),
+    condition_column: str = typer.Option(
+        "condition", help="Column describing shared experimental conditions."
+    ),
+    temperature: float = typer.Option(
+        1.0, help="Boltzmann temperature controlling energy diversity in the proposal."
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Optional path to save the suggested variants as TSV."
+    ),
+    seed: Optional[int] = typer.Option(None, help="Random seed for the Monte Carlo sampler."),
+) -> None:
+    """Rank candidates using BAGEL energy and select a diverse Pareto subset."""
+
+    typer.secho("📂 Loading assay measurements", fg=typer.colors.CYAN)
+    dataset = prepare_multiobjective_dataset(
+        assay_file,
+        objectives=objectives,
+        directions=directions,
+        weights=weights,
+        batch_column=batch_column,
+        condition_column=condition_column,
+        sequence_column=sequence_column,
+    )
+
+    typer.secho("🧠 Preparing Kermut backbone", fg=typer.colors.CYAN)
+    model = prep_kermut(dataset, checkpoint)
+
+    typer.secho("🎲 Running BAGEL-style Monte Carlo", fg=typer.colors.CYAN)
+    planner = BAGELPlanner(dataset, model=model, temperature=temperature, seed=seed)
+    suggestions = planner.suggest(batch_size)
+
+    typer.secho("📊 Collating summary table", fg=typer.colors.CYAN)
+    if "_dataset_index" not in suggestions.columns:
+        raise RuntimeError("Internal error: suggestions missing '_dataset_index' column.")
+
+    dataset_indices = suggestions["_dataset_index"].astype(int).tolist()
+    summary = dataset.summary(dataset_indices)
+    summary.insert(0, "dataset_index", dataset_indices)
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        summary.to_csv(output, sep="\t", index=False)
+        typer.secho(f"✅ Saved {len(summary)} variants to {output}", fg=typer.colors.GREEN)
+    else:
+        typer.echo(summary.to_csv(sep="\t", index=False))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    app()

--- a/strategies/bopo_cli.py
+++ b/strategies/bopo_cli.py
@@ -1,0 +1,198 @@
+"""Typer CLI exposing a BOPO-style Bayesian optimisation loop for Kermut."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+import pandas as pd
+import typer
+
+from .utils_data import PreparedDataset, prepare_multiobjective_dataset, prep_kermut
+from .utils_pareto import non_dominated_sorting, select_diverse
+
+app = typer.Typer(help="BOPO-inspired Bayesian optimisation front-end for Kermut assays.")
+
+
+class BOPOPlanner:
+    """Heuristic Bayesian-style planner leveraging anchor-aware normalisation."""
+
+    def __init__(
+        self,
+        dataset: PreparedDataset,
+        *,
+        model: object | None = None,
+        exploration_weight: float = 0.5,
+        seed: Optional[int] = None,
+    ) -> None:
+        if exploration_weight < 0:
+            raise ValueError("exploration_weight must be non-negative.")
+        self.dataset = dataset
+        self.model = model
+        self.exploration_weight = exploration_weight
+        self.rng = np.random.default_rng(seed)
+
+    def _condition_uncertainty(self) -> np.ndarray:
+        table = self.dataset.table
+        counts = (
+            table.groupby(self.dataset.condition_column)[self.dataset.sequence_column]
+            .transform("count")
+            .to_numpy()
+        )
+        counts = counts.astype(float)
+        counts[counts <= 0] = 1.0
+        uncertainty = 1.0 / np.sqrt(counts)
+        return uncertainty
+
+    def _batch_uncertainty(self) -> np.ndarray:
+        table = self.dataset.table
+        counts = (
+            table.groupby(self.dataset.batch_column)[self.dataset.sequence_column]
+            .transform("count")
+            .to_numpy()
+        )
+        counts = counts.astype(float)
+        counts[counts <= 0] = 1.0
+        return 1.0 / np.sqrt(counts)
+
+    def _novelty_bonus(self) -> np.ndarray:
+        table = self.dataset.table
+        anchor_bonus = np.zeros(len(table), dtype=float)
+        # Reward sequences in batches with large anchor corrections (changed conditions).
+        for batch, offset in self.dataset.anchor_offsets.items():
+            magnitude = float(np.linalg.norm(offset.to_numpy()))
+            if magnitude == 0:
+                continue
+            mask = table[self.dataset.batch_column] == batch
+            anchor_bonus[mask.to_numpy()] = magnitude
+        if anchor_bonus.max() > 0:
+            anchor_bonus = anchor_bonus / anchor_bonus.max()
+        noise = self.rng.normal(scale=0.05, size=len(table))
+        return anchor_bonus + noise
+
+    def acquisition(self) -> pd.Series:
+        table = self.dataset.table
+        exploration = self._condition_uncertainty() + self._batch_uncertainty() + self._novelty_bonus()
+        if np.allclose(exploration.std(), 0):
+            exploration = np.zeros_like(exploration)
+        else:
+            exploration = (exploration - exploration.mean()) / (exploration.std() + 1e-8)
+        acquisition = table[self.dataset.score_column].to_numpy() + self.exploration_weight * exploration
+        return pd.Series(acquisition, index=table.index, name="acquisition")
+
+    def suggest(self, batch_size: int) -> pd.DataFrame:
+        table = self.dataset.table.copy()
+        table["_dataset_index"] = table.index
+        table["acquisition"] = self.acquisition()
+
+        fronts = non_dominated_sorting(table[self.dataset.signed_columns()].to_numpy())
+        selected_frames: list[pd.DataFrame] = []
+        remaining = batch_size
+        for front_indices in fronts:
+            if remaining <= 0:
+                break
+            front_df = table.iloc[front_indices].copy()
+            front_df = front_df.sort_values("acquisition", ascending=False)
+            if len(front_df) <= remaining:
+                selected_frames.append(front_df)
+                remaining -= len(front_df)
+                continue
+            selected = select_diverse(
+                front_df.head(remaining * 3),
+                remaining,
+                feature_columns=self.dataset.signed_columns(),
+            ).sort_values("acquisition", ascending=False)
+            selected_frames.append(selected)
+            remaining -= len(selected)
+        if remaining > 0:
+            leftovers = (
+                table.drop(pd.concat(selected_frames).index)
+                .sort_values("acquisition", ascending=False)
+                .head(remaining)
+            )
+            if not leftovers.empty:
+                selected_frames.append(leftovers)
+        selected = pd.concat(selected_frames, ignore_index=True)
+        if "_dataset_index" not in selected.columns:
+            selected["_dataset_index"] = selected.index
+        return selected
+
+
+@app.command()
+def suggest(
+    assay_file: Path = typer.Argument(..., help="Path to the TSV/CSV assay table."),
+    *,
+    objectives: Sequence[str] = typer.Option(
+        ..., "--objectives", help="Objective column names, e.g. activity stability."
+    ),
+    directions: Sequence[str] = typer.Option(
+        ..., "--directions", help="Optimisation direction for each objective (max/min)."
+    ),
+    weights: Optional[Sequence[float]] = typer.Option(
+        None, "--weights", help="Relative weight for each objective (defaults to 1.0)."
+    ),
+    checkpoint: Optional[Path] = typer.Option(
+        None, "--checkpoint", help="Optional Kermut checkpoint to warm-start from."
+    ),
+    batch_size: int = typer.Option(96, help="Number of variants to return."),
+    exploration_weight: float = typer.Option(
+        0.5,
+        help="Trade-off between exploitation (posterior mean) and exploration bonuses.",
+    ),
+    sequence_column: Optional[str] = typer.Option(
+        None, "--sequence-column", help="Column containing amino-acid sequences."
+    ),
+    batch_column: str = typer.Option("batch", help="Column describing assay batch numbers."),
+    condition_column: str = typer.Option(
+        "condition", help="Column describing shared experimental conditions."
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Optional path to save the suggested variants as TSV."
+    ),
+    seed: Optional[int] = typer.Option(None, help="Random seed controlling tie-breaks."),
+) -> None:
+    """Run a BOPO-inspired acquisition routine on an assay table."""
+
+    typer.secho("📂 Loading assay measurements", fg=typer.colors.CYAN)
+    dataset = prepare_multiobjective_dataset(
+        assay_file,
+        objectives=objectives,
+        directions=directions,
+        weights=weights,
+        batch_column=batch_column,
+        condition_column=condition_column,
+        sequence_column=sequence_column,
+    )
+
+    typer.secho("🧠 Preparing Kermut backbone", fg=typer.colors.CYAN)
+    model = prep_kermut(dataset, checkpoint)
+
+    typer.secho("🤖 Running BOPO acquisition", fg=typer.colors.CYAN)
+    planner = BOPOPlanner(
+        dataset,
+        model=model,
+        exploration_weight=exploration_weight,
+        seed=seed,
+    )
+    suggestions = planner.suggest(batch_size)
+
+    if "_dataset_index" not in suggestions.columns:
+        raise RuntimeError("Internal error: suggestions missing '_dataset_index' column.")
+
+    typer.secho("📊 Collating summary table", fg=typer.colors.CYAN)
+    dataset_indices = suggestions["_dataset_index"].astype(int).tolist()
+    summary = dataset.summary(dataset_indices)
+    summary.insert(0, "dataset_index", dataset_indices)
+    summary["acquisition"] = suggestions["acquisition"].to_numpy()
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        summary.to_csv(output, sep="\t", index=False)
+        typer.secho(f"✅ Saved {len(summary)} variants to {output}", fg=typer.colors.GREEN)
+    else:
+        typer.echo(summary.to_csv(sep="\t", index=False))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    app()

--- a/strategies/utils_data.py
+++ b/strategies/utils_data.py
@@ -1,0 +1,334 @@
+"""Utilities to load multi-objective assay datasets and prepare them for optimisation."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+class Direction(str, Enum):
+    """Optimisation direction for a particular assay objective."""
+
+    MAX = "max"
+    MIN = "min"
+
+    @classmethod
+    def from_string(cls, value: str) -> "Direction":
+        """Normalise user-provided direction strings."""
+
+        value = value.lower().strip()
+        if value in {"max", "maximize", "maximise", "+"}:
+            return cls.MAX
+        if value in {"min", "minimize", "minimise", "-"}:
+            return cls.MIN
+        raise ValueError(f"Unsupported direction '{value}'. Use 'max' or 'min'.")
+
+
+@dataclass(frozen=True)
+class ObjectiveConfig:
+    """Configuration for a single assay objective."""
+
+    name: str
+    direction: Direction
+    weight: float = 1.0
+
+    @property
+    def signed_weight(self) -> float:
+        """Return the weight multiplied by the optimisation sign."""
+
+        return self.weight if self.direction is Direction.MAX else -self.weight
+
+
+@dataclass
+class PreparedDataset:
+    """Container storing a multi-objective dataset and derived metadata."""
+
+    raw: pd.DataFrame
+    table: pd.DataFrame
+    configs: Sequence[ObjectiveConfig]
+    anchor_offsets: Mapping[int, pd.Series]
+    sequence_column: str
+    batch_column: str = "batch"
+    condition_column: str = "condition"
+
+    def objective_columns(self) -> List[str]:
+        """Return the raw objective column names."""
+
+        return [cfg.name for cfg in self.configs]
+
+    def signed_columns(self) -> List[str]:
+        """Return the column names storing direction-adjusted objectives."""
+
+        return [f"{cfg.name}_signed" for cfg in self.configs]
+
+    def aligned_columns(self) -> List[str]:
+        """Return the column names storing anchor-aligned objectives."""
+
+        return [f"{cfg.name}_aligned" for cfg in self.configs]
+
+    @property
+    def energy_column(self) -> str:
+        """Name of the BAGEL-style energy column."""
+
+        return "bagel_energy"
+
+    @property
+    def score_column(self) -> str:
+        """Name of the aggregated weighted score column."""
+
+        return "weighted_score"
+
+    def to_objective_matrix(self) -> np.ndarray:
+        """Return a numpy array of the signed objectives for Pareto sorting."""
+
+        return self.table[self.signed_columns()].to_numpy()
+
+    def summary(self, indices: Sequence[int]) -> pd.DataFrame:
+        """Return a tidy summary table for the requested row indices."""
+
+        base_columns = [self.sequence_column, self.batch_column, self.condition_column]
+        base_columns = [col for col in base_columns if col in self.table.columns]
+        extra_columns = (
+            list(dict.fromkeys(base_columns + self.objective_columns()))
+            + self.aligned_columns()
+            + self.signed_columns()
+            + [self.score_column, self.energy_column]
+        )
+        intersecting = [col for col in extra_columns if col in self.table.columns]
+        return self.table.loc[list(indices), intersecting].reset_index(drop=True)
+
+
+def load_data(
+    path: Path,
+    *,
+    batch_column: str = "batch",
+    condition_column: str = "condition",
+) -> pd.DataFrame:
+    """Load an assay table, automatically detecting the delimiter."""
+
+    if not Path(path).exists():
+        raise FileNotFoundError(f"Assay file not found at {path}")
+
+    path = Path(path)
+    sep = "\t" if path.suffix.lower() in {".tsv", ".txt"} else ","
+    df = pd.read_csv(path, sep=sep)
+
+    for column in (batch_column, condition_column):
+        if column not in df.columns:
+            raise KeyError(
+                f"Required column '{column}' missing from assay file {path.name}."
+            )
+
+    rename: Dict[str, str] = {}
+    if batch_column != "batch":
+        rename[batch_column] = "batch"
+    if condition_column != "condition":
+        rename[condition_column] = "condition"
+    if rename:
+        df = df.rename(columns=rename)
+
+    if df["batch"].isna().any():
+        raise ValueError("Batch column contains missing values.")
+
+    df["batch"] = df["batch"].astype(int)
+    df["condition"] = df["condition"].astype(str)
+    return df
+
+
+def infer_objective_configs(
+    objectives: Sequence[str],
+    directions: Sequence[str],
+    weights: Optional[Sequence[float]] = None,
+) -> List[ObjectiveConfig]:
+    """Build a list of :class:`ObjectiveConfig` from CLI arguments."""
+
+    if not objectives:
+        raise ValueError("At least one objective must be provided.")
+
+    if len(directions) != len(objectives):
+        raise ValueError("Number of directions must match number of objectives.")
+
+    if weights is None:
+        weights = [1.0] * len(objectives)
+    elif len(weights) != len(objectives):
+        raise ValueError("Number of weights must match number of objectives.")
+
+    if not all(weight >= 0 for weight in weights):
+        raise ValueError("Objective weights must be non-negative.")
+
+    configs: List[ObjectiveConfig] = []
+    for name, direction, weight in zip(objectives, directions, weights):
+        configs.append(
+            ObjectiveConfig(name=name, direction=Direction.from_string(direction), weight=weight)
+        )
+    return configs
+
+
+def compute_anchor_offsets(
+    df: pd.DataFrame,
+    objectives: Sequence[str],
+    *,
+    batch_column: str = "batch",
+    condition_column: str = "condition",
+) -> Dict[int, pd.Series]:
+    """Estimate per-batch offsets using anchor conditions observed across rounds."""
+
+    if batch_column not in df.columns or condition_column not in df.columns:
+        raise KeyError("Data frame must contain batch and condition columns for alignment.")
+
+    batches = sorted(df[batch_column].unique())
+    if not batches:
+        raise ValueError("The dataset does not contain any batches.")
+
+    base_batch = batches[0]
+    offsets: Dict[int, pd.Series] = {}
+    base = (
+        df[df[batch_column] == base_batch]
+        .groupby(condition_column)[list(objectives)]
+        .mean(numeric_only=True)
+    )
+
+    zero = pd.Series(0.0, index=objectives, dtype=float)
+    offsets[base_batch] = zero
+
+    for batch in batches[1:]:
+        current = (
+            df[df[batch_column] == batch]
+            .groupby(condition_column)[list(objectives)]
+            .mean(numeric_only=True)
+        )
+        overlap = current.index.intersection(base.index)
+        if len(overlap) == 0:
+            offsets[batch] = zero.copy()
+            continue
+        diff = current.loc[overlap, objectives] - base.loc[overlap, objectives]
+        offsets[batch] = diff.mean(axis=0)
+    return offsets
+
+
+def apply_anchor_offsets(
+    df: pd.DataFrame,
+    offsets: Mapping[int, pd.Series],
+    objectives: Sequence[str],
+    *,
+    batch_column: str = "batch",
+) -> pd.DataFrame:
+    """Return a new data frame where objectives are aligned using anchor offsets."""
+
+    adjusted = df.copy()
+    aligned_columns = {obj: f"{obj}_aligned" for obj in objectives}
+
+    for obj in objectives:
+        adjusted[aligned_columns[obj]] = adjusted[obj]
+
+    for batch, offset in offsets.items():
+        mask = adjusted[batch_column] == batch
+        if mask.any():
+            adjusted.loc[mask, list(aligned_columns.values())] = (
+                adjusted.loc[mask, objectives]
+                - np.asarray([offset[obj] for obj in objectives])
+            )
+    return adjusted
+
+
+def add_directional_scores(
+    df: pd.DataFrame,
+    configs: Sequence[ObjectiveConfig],
+) -> pd.DataFrame:
+    """Attach direction-adjusted and weighted scores required by the strategies."""
+
+    scored = df.copy()
+    score = np.zeros(len(scored), dtype=float)
+    for config in configs:
+        aligned_col = f"{config.name}_aligned"
+        if aligned_col not in scored.columns:
+            raise KeyError(
+                f"Aligned column '{aligned_col}' missing. Did you call apply_anchor_offsets?"
+            )
+        signed_col = f"{config.name}_signed"
+        sign = 1.0 if config.direction is Direction.MAX else -1.0
+        scored[signed_col] = scored[aligned_col] * sign
+        score = score + scored[signed_col] * config.weight
+    scored["weighted_score"] = score
+    scored["bagel_energy"] = -score
+    return scored
+
+
+def infer_sequence_column(df: pd.DataFrame, preferred: str = "sequence") -> str:
+    """Best-effort detection of the sequence column in the assay table."""
+
+    candidates = [preferred, "mutated_sequence", "sequence_str", "protein_sequence"]
+    for candidate in candidates:
+        if candidate in df.columns:
+            return candidate
+    raise KeyError(
+        "Unable to locate a sequence column. Provide --sequence-column in the CLI."
+    )
+
+
+def prepare_multiobjective_dataset(
+    path: Path,
+    objectives: Sequence[str],
+    directions: Sequence[str],
+    weights: Optional[Sequence[float]] = None,
+    *,
+    batch_column: str = "batch",
+    condition_column: str = "condition",
+    sequence_column: Optional[str] = None,
+) -> PreparedDataset:
+    """Load a dataset, align batches, and attach scoring metadata."""
+
+    raw = load_data(path, batch_column=batch_column, condition_column=condition_column)
+    configs = infer_objective_configs(objectives, directions, weights)
+
+    for config in configs:
+        if config.name not in raw.columns:
+            raise KeyError(f"Objective column '{config.name}' not present in the assay table.")
+
+    seq_col = sequence_column or infer_sequence_column(raw)
+
+    offsets = compute_anchor_offsets(
+        raw,
+        [cfg.name for cfg in configs],
+        batch_column="batch",
+        condition_column="condition",
+    )
+    aligned = apply_anchor_offsets(raw, offsets, [cfg.name for cfg in configs])
+    scored = add_directional_scores(aligned, configs)
+
+    return PreparedDataset(
+        raw=raw,
+        table=scored,
+        configs=configs,
+        anchor_offsets=offsets,
+        sequence_column=seq_col,
+        batch_column="batch",
+        condition_column="condition",
+    )
+
+
+def prep_kermut(
+    dataset: PreparedDataset,
+    checkpoint: Optional[Path] = None,
+    *,
+    fine_tune: bool = True,
+    extra_config: Optional[Mapping[str, object]] = None,
+) -> object:
+    """Placeholder for integrating Kermut fine-tuning within the strategies."""
+
+    warnings.warn(
+        "prep_kermut is a stub. Plug in your project-specific fine-tuning routine.",
+        stacklevel=2,
+    )
+    return {
+        "checkpoint": Path(checkpoint) if checkpoint else None,
+        "fine_tune": fine_tune,
+        "config": extra_config or {},
+        "n_sequences": len(dataset.table),
+    }

--- a/strategies/utils_pareto.py
+++ b/strategies/utils_pareto.py
@@ -1,0 +1,115 @@
+"""Pareto front utilities shared across strategy implementations."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def dominates(a: np.ndarray, b: np.ndarray) -> bool:
+    """Return ``True`` if point ``a`` dominates point ``b`` in maximisation sense."""
+
+    return np.all(a >= b) and np.any(a > b)
+
+
+def non_dominated_sorting(points: np.ndarray) -> List[List[int]]:
+    """Fast non-dominated sorting for a set of points."""
+
+    if points.ndim != 2:
+        raise ValueError("Points array must be two-dimensional.")
+
+    n_points = points.shape[0]
+    domination_counts = np.zeros(n_points, dtype=int)
+    dominated: List[List[int]] = [[] for _ in range(n_points)]
+    fronts: List[List[int]] = [[]]
+
+    for p in range(n_points):
+        for q in range(n_points):
+            if p == q:
+                continue
+            if dominates(points[p], points[q]):
+                dominated[p].append(q)
+            elif dominates(points[q], points[p]):
+                domination_counts[p] += 1
+        if domination_counts[p] == 0:
+            fronts[0].append(p)
+
+    front_idx = 0
+    while fronts[front_idx]:
+        next_front: List[int] = []
+        for p in fronts[front_idx]:
+            for q in dominated[p]:
+                domination_counts[q] -= 1
+                if domination_counts[q] == 0:
+                    next_front.append(q)
+        front_idx += 1
+        fronts.append(next_front)
+    if not fronts[-1]:
+        fronts.pop()
+    return fronts
+
+
+def _max_min_diversity(features: np.ndarray, k: int) -> List[int]:
+    """Greedy max-min diversity selection."""
+
+    if features.ndim != 2:
+        raise ValueError("Features must be two-dimensional.")
+    n = features.shape[0]
+    if k >= n:
+        return list(range(n))
+
+    norms = np.linalg.norm(features, axis=1)
+    first = int(np.argmax(norms))
+    selected = [first]
+    remaining = set(range(n))
+    remaining.remove(first)
+
+    while len(selected) < k and remaining:
+        best_idx = None
+        best_distance = -np.inf
+        for idx in list(remaining):
+            dist = min(
+                float(np.linalg.norm(features[idx] - features[sel])) for sel in selected
+            )
+            if dist > best_distance:
+                best_distance = dist
+                best_idx = idx
+        if best_idx is None:
+            break
+        selected.append(best_idx)
+        remaining.remove(best_idx)
+    return selected
+
+
+def select_diverse(
+    front: pd.DataFrame,
+    k: int,
+    *,
+    feature_columns: Sequence[str] | None = None,
+    embeddings: np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Select a diverse subset from the provided Pareto front."""
+
+    if k <= 0:
+        raise ValueError("k must be positive.")
+    if len(front) == 0:
+        return front.copy()
+
+    if embeddings is not None:
+        if embeddings.shape[0] != len(front):
+            raise ValueError("Embeddings must match the number of rows in the front.")
+        features = embeddings
+    else:
+        if not feature_columns:
+            raise ValueError(
+                "feature_columns must be provided when embeddings are not supplied."
+            )
+        for column in feature_columns:
+            if column not in front.columns:
+                raise KeyError(f"Feature column '{column}' missing from Pareto front data frame.")
+        features = front.loc[:, feature_columns].to_numpy()
+
+    indices = _max_min_diversity(features, k)
+    return front.iloc[indices]


### PR DESCRIPTION
## Summary
- add a `strategies` package that prepares multi-objective assay datasets with anchor-aware normalisation helpers
- implement `bagel_cli.py` to expose a BAGEL-style Monte Carlo Typer command with Pareto diversity selection
- implement `bopo_cli.py` to offer a BOPO-inspired Typer command backed by reusable Pareto utilities and dataset preparation stubs

## Testing
- `python -m strategies.bagel_cli --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68d451fa1df88330b0b28efb81aa084d