### PR TITLE
Add reusable ProteinMPNN conditional probability scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The structure-conditioned amino acid distributions for all residues and assays, 
 ```
 bash example_scripts/conditional_probabilities.sh
 ```
-For a single dataset, see `example_scripts/conditional_probabilities_single.sh` or `example_scripts/conditional_probabilities_all.sh`. This generates per-assay directories in `data/conditional_probs/raw_ProteinMPNN_outputs`. After this, postprocessing for easier access is performed via
+The script defaults to reading assay identifiers from `data/DMS_substitutions.csv` but honours an `ASSAYS_FILE` environment variable if set. For a single dataset, see `example_scripts/conditional_probabilities_single.sh` or `example_scripts/conditional_probabilities_all.sh`. This generates per-assay directories in `data/conditional_probs/raw_ProteinMPNN_outputs`. After this, postprocessing for easier access is performed via
 ```bash
 python -m kermut.cmdline.preprocess_data.extract_ProteinMPNN_probs \ 
     dataset=all

--- a/example_scripts/conditional_probabilities.sh
+++ b/example_scripts/conditional_probabilities.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${PROTEINMPNN_DIR:-}" ]]; then
+    echo "PROTEINMPNN_DIR environment variable must be set to the ProteinMPNN checkout." >&2
+    exit 1
+fi
+
+python_bin=${PYTHON_BIN:-python}
+
+declare -a datasets
+if [[ $# -gt 0 ]]; then
+    datasets=("$@")
+else
+    assays_file=${ASSAYS_FILE:-data/DMS_substitutions.csv}
+    if [[ ! -f "${assays_file}" ]]; then
+        echo "Assay reference file not found: ${assays_file}" >&2
+        exit 1
+    fi
+    mapfile -t datasets < <(awk -F"," 'NR > 1 {gsub(/"/, "", $3); if ($3 != "") print $3}' "${assays_file}")
+fi
+
+if [[ ${#datasets[@]} -eq 0 ]]; then
+    echo "No assay identifiers supplied." >&2
+    exit 1
+fi
+
+run_proteinmpnn() {
+    local pdb_path=$1
+    local dataset_id=$2
+
+    if [[ ! -f "${pdb_path}" ]]; then
+        echo "Skipping ${dataset_id}: missing PDB file at ${pdb_path}" >&2
+        return
+    fi
+
+    local output_dir="data/conditional_probs/raw_ProteinMPNN_outputs/${dataset_id}/proteinmpnn"
+    mkdir -p "${output_dir}"
+
+    ${python_bin} "${PROTEINMPNN_DIR}/protein_mpnn_run.py" \
+        --pdb_path "${pdb_path}" \
+        --save_score 1 \
+        --conditional_probs_only 1 \
+        --num_seq_per_target 10 \
+        --batch_size 1 \
+        --out_folder "${output_dir}" \
+        --seed 37
+}
+
+for dataset in "${datasets[@]}"; do
+    echo "Processing ${dataset}..."
+    if [[ "${dataset}" == "BRCA2_HUMAN" ]]; then
+        for suffix in "_1-1000" "_1001-2085" "_2086-2832"; do
+            run_proteinmpnn "data/structures/pdbs/${dataset}${suffix}.pdb" "${dataset}"
+        done
+    else
+        run_proteinmpnn "data/structures/pdbs/${dataset}.pdb" "${dataset}"
+    fi
+    echo "Finished ${dataset}."
+    echo
+done

--- a/example_scripts/conditional_probabilities_all.sh
+++ b/example_scripts/conditional_probabilities_all.sh
@@ -1,46 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Specify path to ProteinMPNN installation 
-protein_mpnn_dir=$PROTEINMPNN_DIR
+set -euo pipefail
 
-# Majority of assays
-for DATASET in $(awk -F "\"*,\"*" '{print $3}' $ASSAYS_FILE)
-do
-    path_to_PDB="data/structures/pdbs/${DATASET}.pdb"
-    output_dir="data/conditional_probs/raw_ProteinMPNN_outputs/${DATASET}/proteinmpnn"
+assays_file=${ASSAYS_FILE:-data/DMS_substitutions.csv}
+if [[ ! -f "${assays_file}" ]]; then
+    echo "Assay reference file not found: ${assays_file}" >&2
+    exit 1
+fi
 
-    if [ ! -d $output_dir ]
-    then
-        mkdir -p $output_dir
-    fi
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-    python $protein_mpnn_dir/protein_mpnn_run.py \
-            --pdb_path $path_to_PDB \
-            --save_score 1 \
-            --conditional_probs_only 1 \
-            --num_seq_per_target 10 \
-            --batch_size 1 \
-            --out_folder $output_dir \
-            --seed 37
-done
-
-# Special case 
-DATASET=BRCA2_HUMAN
-for SUFFIX in "_1-1000" "_1001-2085" "_2086-2832"
-do
-    path_to_PDB="data/structures/pdbs/${DATASET}${SUFFIX}.pdb"
-    output_dir="data/conditional_probs/raw_ProteinMPNN_outputs/${DATASET}/proteinmpnn"
-    if [ ! -d $output_dir ]
-    then
-        mkdir -p $output_dir
-    fi
-
-    python $protein_mpnn_dir/protein_mpnn_run.py \
-        --pdb_path $path_to_PDB \
-        --save_score 1 \
-        --conditional_probs_only 1 \
-        --num_seq_per_target 10 \
-        --batch_size 1 \
-        --out_folder $output_dir \
-        --seed 37
+awk -F"," 'NR > 1 {gsub(/"/, "", $3); if ($3 != "") print $3}' "${assays_file}" |
+while IFS= read -r dataset; do
+    "${script_dir}/conditional_probabilities.sh" "${dataset}"
 done

--- a/example_scripts/conditional_probabilities_single.sh
+++ b/example_scripts/conditional_probabilities_single.sh
@@ -1,25 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Specify path to ProteinMPNN installation 
-protein_mpnn_dir=$PROTEINMPNN_DIR
+set -euo pipefail
 
-# Majority of assays
-DATASET=TCRG1_MOUSE
-path_to_PDB="data/structures/pdbs/${DATASET}.pdb"
-output_dir="data/conditional_probs/raw_ProteinMPNN_outputs/${DATASET}/proteinmpnn"
+dataset=${1:-TCRG1_MOUSE}
 
-if [ ! -d $output_dir ]
-then
-    mkdir -p $output_dir
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+"${script_dir}/conditional_probabilities.sh" "${dataset}"
+
+echo "Generated conditional probabilities for ${dataset}."
+
+if [[ "${dataset}" != "BRCA2_HUMAN" ]]; then
+    echo "Note: BRCA2_HUMAN requires multiple PDB segments. See conditional_probabilities.sh." >&2
 fi
-
-python $protein_mpnn_dir/protein_mpnn_run.py \
-        --pdb_path $path_to_PDB \
-        --save_score 1 \
-        --conditional_probs_only 1 \
-        --num_seq_per_target 10 \
-        --batch_size 1 \
-        --out_folder $output_dir \
-        --seed 37
-
-# Note: BRCA2_HUMAN is a special case. See example_scripts/conditional_probabilities_all.sh for details.


### PR DESCRIPTION
## Summary
- add a reusable `conditional_probabilities.sh` helper that can process one or all assays
- refactor the single- and all-assay example scripts to reuse the helper and ensure executable shebangs
- document the optional `ASSAYS_FILE` override in the README

## Testing
- bash -n example_scripts/conditional_probabilities.sh
- bash -n example_scripts/conditional_probabilities_all.sh
- bash -n example_scripts/conditional_probabilities_single.sh
- python example_scripts/bopo_multiobj_pipeline_test.py

------
https://chatgpt.com/codex/tasks/task_b_68d456a1d1388330aaf27c696806edc1