### PR TITLE
Fix neighbour proposal mutation bounds

### DIFF
--- a/kermut_ext/seq_utils.py
+++ b/kermut_ext/seq_utils.py
@@ -26,25 +26,48 @@ def propose_neighbors(
     rng: np.random.Generator,
     max_candidates: int = 200,
 ) -> Iterator[str]:
-    """Yield neighbouring sequences via single-position perturbations."""
+    """Yield neighbouring sequences with bounded Hamming distance."""
 
     if min_muts > max_muts:
         raise ValueError("min_muts must be less than or equal to max_muts")
+    if min_muts < 0:
+        raise ValueError("min_muts must be non-negative")
 
     length = len(current)
     sites = list(site_pool) if site_pool is not None else list(range(length))
-    seen: set[str] = set()
+    if not sites:
+        raise ValueError("site_pool must contain at least one position")
 
-    while len(seen) < max_candidates:
-        idx = int(rng.choice(sites))
-        mutated = list(current)
-        aa = AA_ALPHABET[rng.integers(0, len(AA_ALPHABET))]
-        if aa == mutated[idx]:
+    max_mutations = min(max_muts, len(sites))
+    if min_muts > max_mutations:
+        raise ValueError("Not enough mutable sites for the requested min_muts")
+
+    seen: set[str] = set()
+    attempts = 0
+    max_attempts = max(1, max_candidates) * 20
+
+    while len(seen) < max_candidates and attempts < max_attempts:
+        attempts += 1
+        n_mut = int(rng.integers(min_muts, max_mutations + 1))
+
+        if n_mut == 0:
             continue
-        mutated[idx] = aa
+
+        positions = rng.choice(sites, size=n_mut, replace=False)
+        mutated = list(current)
+
+        for raw_idx in np.atleast_1d(positions):
+            idx = int(raw_idx)
+            original = mutated[idx]
+            choices = [aa for aa in AA_ALPHABET if aa != original]
+            mutated[idx] = str(rng.choice(choices))
+
         proposal = "".join(mutated)
-        n_mut = count_muts(current, proposal)
-        if min_muts <= n_mut <= max_muts and proposal not in seen:
+        if proposal == current or proposal in seen:
+            continue
+
+        distance = count_muts(current, proposal)
+        if min_muts <= distance <= max_muts:
             seen.add(proposal)
             yield proposal
 

--- a/tests/test_seq_utils.py
+++ b/tests/test_seq_utils.py
@@ -1,0 +1,44 @@
+import itertools
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from kermut_ext.seq_utils import count_muts, propose_neighbors
+
+
+def test_propose_neighbors_respects_bounds() -> None:
+    rng = np.random.default_rng(123)
+    current = "ACDEFG"
+    neighbours = list(
+        itertools.islice(
+            propose_neighbors(
+                current,
+                min_muts=2,
+                max_muts=4,
+                rng=rng,
+                max_candidates=25,
+            ),
+            25,
+        )
+    )
+    assert neighbours, "Expected at least one neighbour"
+    assert len(set(neighbours)) == len(neighbours)
+    for neighbour in neighbours:
+        distance = count_muts(current, neighbour)
+        assert 2 <= distance <= 4
+
+
+def test_propose_neighbors_validates_pool_size() -> None:
+    rng = np.random.default_rng(0)
+    with pytest.raises(ValueError):
+        list(
+            propose_neighbors(
+                "AAAA",
+                min_muts=3,
+                max_muts=5,
+                site_pool=[0, 1],
+                rng=rng,
+                max_candidates=5,
+            )
+        )


### PR DESCRIPTION
## Summary
- update `propose_neighbors` to honour mutation bounds and guard against impossible site pools
- add regression tests covering neighbour generation edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d456bd04608330b60480905558a256