### PR TITLE
Add openpyxl to CPU requirements list

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -7,6 +7,7 @@ gpytorch
 hydra-core
 omegaconf
 typer
+openpyxl
 # Pin NumPy to the 1.26 minor release to match the PyTorch wheel ABI.
 numpy>=1.26,<1.27
 pandas


### PR DESCRIPTION
## Summary
- include openpyxl in requirements_cpu.txt so the QuaRALowP pipeline dependencies are tracked

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d4661f38288330ba288ad8dabae0e8